### PR TITLE
fix: support promise or observable from runner

### DIFF
--- a/packages/nx-aws-cache/src/tasks-runner/runner.ts
+++ b/packages/nx-aws-cache/src/tasks-runner/runner.ts
@@ -52,7 +52,7 @@ export const tasksRunner = (
       },
     });
 
-    return runnerWrapper;
+    return runnerWrapper.toPromise();
   } catch (err) {
     logger.warn(err.message);
     logger.note('USING LOCAL CACHE');

--- a/packages/nx-aws-cache/src/tasks-runner/runner.ts
+++ b/packages/nx-aws-cache/src/tasks-runner/runner.ts
@@ -5,7 +5,7 @@ dotEnvConfig();
 
 import defaultTaskRunner from '@nrwl/workspace/tasks-runners/default';
 import { AffectedEvent } from '@nrwl/workspace/src/tasks-runner/tasks-runner';
-import { Subject } from 'rxjs';
+import { from, Subject } from 'rxjs';
 
 import { AwsNxCacheOptions } from './models/aws-nx-cache-options.model';
 import { AwsCache } from './aws-cache';
@@ -42,7 +42,7 @@ export const tasksRunner = (
         context,
       );
 
-    runner$.subscribe({
+    from(runner$).subscribe({
       next: (value) => runnerWrapper.next(value),
       error: (err) => runnerWrapper.error(err),
       complete: async () => {


### PR DESCRIPTION
In the new versions of Nx the task runner no longer returns an observable. This change will support both new and old versions.