### PR TITLE
wrong variable naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ There are two ways to set-up AWS options:
       "awsRegion": "eu-central-1",
       "awsBucket": "bucket-name",
       "awsProfile": "profile-1",
-      "awsEndpoint": "custom.de-eu.myhost.com",
+      "awsEndpoint": "http://custom.de-eu.myhost.com",
     }
   }
 }

--- a/packages/nx-aws-cache/src/tasks-runner/runner.ts
+++ b/packages/nx-aws-cache/src/tasks-runner/runner.ts
@@ -17,7 +17,7 @@ function getOptions(options: AwsNxCacheOptions) {
     awsRegion: options.awsRegion ?? process.env.NX_AWS_REGION,
     awsSecretAccessKey: process.env.NX_AWS_SECRET_ACCESS_KEY,
     awsProfile: options.awsProfile ?? process.env.NX_AWS_PROFILE,
-    awsEndpoint: options.awsProfile ?? process.env.NX_AWS_ENDPOINT,
+    awsEndpoint: options.awsEndpoint ?? process.env.NX_AWS_ENDPOINT,
   };
 }
 


### PR DESCRIPTION
- During testing I found a copy/paste issue created by me. Sorry for that!  awsEndpoint variable in angular.json was not working with current implementation
- Additional I've added the protocol in the example, in the README.md, without the protocol it's not working. 