### PR TITLE
Prevent Potential Exposure of AWS Keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ There are two ways to set-up AWS options:
 ### Using environment variables
 
 ```bash
-NX_AWS_REGION=eu-central-1
-NX_AWS_BUCKET=bucket-name
-NX_AWS_PROFILE=profile-1
-NX_AWS_ENDPOINT=[URL] # default s3.[region].amazonaws.com
+NXCACHE_AWS_REGION=eu-central-1
+NXCACHE_AWS_BUCKET=bucket-name
+NXCACHE_AWS_PROFILE=profile-1
+NXCACHE_AWS_ENDPOINT=[URL] # default s3.[region].amazonaws.com
 ```
 
 > Environment variables can be set using `.env` file - check [dotenv documentation](https://www.npmjs.com/package/dotenv).
@@ -62,7 +62,7 @@ NX_AWS_ENDPOINT=[URL] # default s3.[region].amazonaws.com
 Remote cache can be disabled in favor of local cache only using an environment variable
 
 ```bash
-NX_AWS_DISABLE=true
+NXCACHE_AWS_DISABLE=true
 ```
 
 ## Authentication
@@ -84,8 +84,8 @@ AWS SDK v3 is used under the hood with a support for [SSO login](https://docs.aw
 Custom environment variables can be set for an alternate way of authentication
 
 ```bash
-NX_AWS_ACCESS_KEY_ID=[secret]
-NX_AWS_SECRET_ACCESS_KEY=[secret]
+NXCACHE_AWS_ACCESS_KEY_ID=[secret]
+NXCACHE_AWS_SECRET_ACCESS_KEY=[secret]
 ```
 
 ## Build

--- a/packages/nx-aws-cache/src/tasks-runner/aws-cache.ts
+++ b/packages/nx-aws-cache/src/tasks-runner/aws-cache.ts
@@ -50,7 +50,7 @@ export class AwsCache implements RemoteCache {
     const missingOptions: Array<string> = [];
 
     if (!options.awsBucket) {
-      missingOptions.push('NX_AWS_BUCKET | awsBucket');
+      missingOptions.push('NXCACHE_AWS_BUCKET | awsBucket');
     }
 
     if (missingOptions.length > 0) {

--- a/packages/nx-aws-cache/src/tasks-runner/logger.ts
+++ b/packages/nx-aws-cache/src/tasks-runner/logger.ts
@@ -3,7 +3,7 @@ import * as chalk from 'chalk';
 
 export class Logger {
   public debug(message: string): void {
-    if (!process.env.NX_VERBOSE_LOGGING) {
+    if (!process.env['NX-CACHE_VERBOSE_LOGGING']) {
       return;
     }
 

--- a/packages/nx-aws-cache/src/tasks-runner/runner.ts
+++ b/packages/nx-aws-cache/src/tasks-runner/runner.ts
@@ -11,12 +11,12 @@ import { MessageReporter } from './message-reporter';
 
 function getOptions(options: AwsNxCacheOptions) {
   return {
-    awsAccessKeyId: process.env.NX_AWS_ACCESS_KEY_ID,
-    awsBucket: options.awsBucket ?? process.env.NX_AWS_BUCKET,
-    awsRegion: options.awsRegion ?? process.env.NX_AWS_REGION,
-    awsSecretAccessKey: process.env.NX_AWS_SECRET_ACCESS_KEY,
-    awsProfile: options.awsProfile ?? process.env.NX_AWS_PROFILE,
-    awsEndpoint: options.awsEndpoint ?? process.env.NX_AWS_ENDPOINT,
+    awsAccessKeyId: process.env.NXCACHE_ACCESS_KEY_ID,
+    awsBucket: options.awsBucket ?? process.env.NXCACHE_BUCKET,
+    awsRegion: options.awsRegion ?? process.env.NXCACHE_REGION,
+    awsSecretAccessKey: process.env.NXCACHE_SECRET_ACCESS_KEY,
+    awsProfile: options.awsProfile ?? process.env.NXCACHE_PROFILE,
+    awsEndpoint: options.awsEndpoint ?? process.env.NXCACHE_ENDPOINT,
   };
 }
 
@@ -31,8 +31,8 @@ export const tasksRunner = (
   const logger = new Logger();
 
   try {
-    if (process.env.NX_AWS_DISABLE === 'true') {
-      logger.note('USING LOCAL CACHE (NX_AWS_DISABLE is set to true)');
+    if (process.env.NXCACHE_AWS_DISABLE === 'true') {
+      logger.note('USING LOCAL CACHE (NXCACHE_AWS_DISABLE is set to true)');
 
       return defaultTasksRunner(tasks, options, context);
     }


### PR DESCRIPTION
This PR addresses a security concern related to the handling of AWS environment variables within nx-aws.

Currently, nx-aws utilizes environment variables prefixed with `NX_`, such as `NX_AWS_ACCESS_KEY` and `NX_AWS_SECRET_ACCESS_KEY`, for configuration. However, due to nx's default behavior, these variables may be unintentionally exposed.

By default, nx injects variables prefixed with `NX_` into React client bundles. Any environment variables like `NX_AWS_ACCESS_KEY` and `NX_AWS_SECRET_ACCESS_KEY` are potentially injected into the frontend bundle and served on the public web, making them accessible to potential attackers. 

This PR proposes to change the prefix used for environment variables within nx-aws. While this represents a breaking change, the security implications should justify this action. 

A part that I haven't fully dug into is if this project itself requires on nx loading the `NX_` prefixed variables to function. As the package.json file lists dotenv I'd think we are fine


References:
- [Nx documentation on handling environment variables](https://nx.dev/recipes/environment-variables/use-environment-variables-in-react)
