### PR TITLE
chore: disable `USING REMOTE CACHE` logging when `--skip-nx-cache` is provided

### DIFF
--- a/packages/nx-aws-cache/src/tasks-runner/runner.ts
+++ b/packages/nx-aws-cache/src/tasks-runner/runner.ts
@@ -35,12 +35,16 @@ export const tasksRunner = (
 
   try {
     if (process.env.NXCACHE_AWS_DISABLE === 'true') {
-      logger.note('USING LOCAL CACHE (NXCACHE_AWS_DISABLE is set to true)');
+      if (!options.skipNxCache) {
+        logger.note('USING LOCAL CACHE (NXCACHE_AWS_DISABLE is set to true)');
+      }
 
       return defaultTasksRunner(tasks, options, context);
     }
 
-    logger.note('USING REMOTE CACHE');
+    if (!options.skipNxCache) {
+      logger.note('USING REMOTE CACHE');
+    }
 
     const messages = new MessageReporter(logger);
     const remoteCache = new AwsCache(awsOptions, messages);


### PR DESCRIPTION
This PR changes the custom task runner to not print the `USING REMOTE CACHE` when the `--skip-nx-cache` CLI option is provided.

This message might be confusing when you specify `--skip-nx-cache` and you still see the `USING REMOTE CACHE`, seems like the `--skip-nx-cache` is not working, but it is.

#### Issues

#340 