### PR TITLE
Fix: Using bucket path on windows and linux makes different cache files

### DIFF
--- a/packages/nx-aws-cache/src/tasks-runner/aws-cache.ts
+++ b/packages/nx-aws-cache/src/tasks-runner/aws-cache.ts
@@ -1,5 +1,6 @@
 import { createReadStream, createWriteStream, writeFile } from 'fs';
 import { join, dirname } from 'path';
+import { join as posixJoin } from 'path/posix';
 import { pipeline, Readable } from 'stream';
 import { promisify } from 'util';
 import * as clientS3 from '@aws-sdk/client-s3';
@@ -179,7 +180,7 @@ export class AwsCache implements RemoteCache {
   }
 
   private getS3Key(tgzFileName: string) {
-    return join(this.path, tgzFileName);
+    return posixJoin(this.path, tgzFileName);
   }
 
   /**


### PR DESCRIPTION
if i use option awsBucket: "bucket-name/path-to-a-folder" 

in windows will create 
```
bucket-name
  "path-to-a-folder\hash.tgz"
```

and in linux `
```
bucket-name
   path-to-a-folder
      "hash.tgz"
```

making different caches for each of them