### PR TITLE
Return false from checkIfCacheExists when error is 403

### DIFF
--- a/packages/nx-aws-cache/src/tasks-runner/aws-cache.ts
+++ b/packages/nx-aws-cache/src/tasks-runner/aws-cache.ts
@@ -246,7 +246,8 @@ export class AwsCache implements RemoteCache {
       await this.s3.send(params);
       return true;
     } catch (err) {
-      if ((err as Error).name === 'NotFound') {
+      if ((err as Error).name === '403' ||
+          (err as Error).name === 'NotFound') {
         return false;
       } else if (err instanceof CredentialsProviderError) {
         return false;


### PR DESCRIPTION
Fixes issue #433

When GetHeadObject command is returned if you don't have `s3:ListBucket` permissions, then you will receive a 403 error. This case would still indicate that the bucket object exists. 

See: https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/s3/command/HeadObjectCommand/

> General purpose bucket permissions - To use HEAD, you must have the s3:GetObject permission. You need the relevant read object (or version) permission for this operation. For more information, see [Actions, resources, and condition keys for Amazon S3 ](https://docs.aws.amazon.com/AmazonS3/latest/dev/list_amazons3.html)
>  in the Amazon S3 User Guide.
> 
> If the object you request doesn't exist, the error that Amazon S3 returns depends on whether you also have the s3:ListBucket permission.
> 
> If you have the s3:ListBucket permission on the bucket, Amazon S3 returns an HTTP status code 404 Not Found error.
> 
> If you don’t have the s3:ListBucket permission, Amazon S3 returns an HTTP status code 403 Forbidden error

The same solution exists in the `nx-remotecache-s3` project 

https://github.com/robinpellegrims/pellegrims/blob/master/libs/nx-remotecache-s3/src/lib/setup-s3-task-runner.ts#L44-L45